### PR TITLE
Add barrel export

### DIFF
--- a/packages/multiply/src/index.ts
+++ b/packages/multiply/src/index.ts
@@ -1,9 +1,1 @@
-import { sum } from "@myrepo/sum";
-
-export function multiply(a: number, b: number) {
-  let total = 0;
-  for (let count = 0; count < b; count++) {
-    total = sum(total, a);
-  }
-  return total;
-}
+export * from "./multiply.js";

--- a/packages/multiply/src/index.ts
+++ b/packages/multiply/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./multiply.js";
+export * from "./multiply.ts";

--- a/packages/multiply/src/multiply.ts
+++ b/packages/multiply/src/multiply.ts
@@ -1,0 +1,9 @@
+import { sum } from "@myrepo/sum";
+
+export function multiply(a: number, b: number) {
+  let total = 0;
+  for (let count = 0; count < b; count++) {
+    total = sum(total, a);
+  }
+  return total;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -109,7 +109,9 @@
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "paths": {
       "@myrepo/*": ["./packages/*/src/index.ts"]
-    }
+    },
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This modification (to add barrel exports) emphasises that there was still a failing in the bundling and resolution strategy. The previous solution only got the NextJS bundling process as far as the .ts files, and the stupidity of the convention to require .js files was defeating the bundler's attempts to resolve source.

See https://github.com/microsoft/TypeScript/issues/49083#issuecomment-1125258055 for the original intransigent position taken by the Typescript team and then see https://github.com/microsoft/TypeScript/pull/59767 for when they (very recently) saw the light!

This means we can add `.ts` file paths in imports, assuming we add the following to our tsconfig.json `compilerOptions`

```
    "allowImportingTsExtensions": true,
    "rewriteRelativeImportExtensions": true
```